### PR TITLE
moving the inclusion of jcache-tck-runner to a run-tck profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,19 @@ Modules
 * [jcache-tck-runner](https://github.com/jsr107/ehcache-jcache/tree/master/ehcache-jcache/jcache-tck-runner/)
   This runs the JSR107 TCK suite against the ehcache-jcache implementation to verify compliance with the spec.
 
+
+Build
+--------------------
+* Just run the following command line (provided you have maven 3 already installed) :
+
+    mvn clean install
+
+
+* You may want to disable the run-tck profile (if you don't have it in your local maven repository) since it's not published to a maven repository :
+
+    mvn clean install -P -run-tck
+
+
 IRC
 ---
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,6 @@
 
     <modules>
         <module>ehcache-jcache</module>
-        <module>jcache-tck-runner</module>
     </modules>
 
     <dependencyManagement>
@@ -60,6 +59,16 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <!--You can disable this profile on the command line using -P -run-tck -->
+            <id>run-tck</id>
+                <activation>
+                    <activeByDefault>true</activeByDefault>
+                </activation>
+                <modules>
+                    <module>jcache-tck-runner</module>
+                </modules>
         </profile>
     </profiles>
 


### PR DESCRIPTION
profile activated by default (can be disabled using -P -run-tck on the command line)
