### PR TITLE
fixes NPE in JCacheConfiguration

### DIFF
--- a/ehcache-jcache/src/main/java/org/ehcache/jcache/JCacheConfiguration.java
+++ b/ehcache-jcache/src/main/java/org/ehcache/jcache/JCacheConfiguration.java
@@ -29,6 +29,7 @@ import javax.cache.configuration.CacheEntryListenerConfiguration;
 import javax.cache.configuration.CompleteConfiguration;
 import javax.cache.configuration.Configuration;
 import javax.cache.configuration.Factory;
+import javax.cache.configuration.FactoryBuilder;
 import javax.cache.expiry.Duration;
 import javax.cache.expiry.EternalExpiryPolicy;
 import javax.cache.expiry.ExpiryPolicy;
@@ -89,7 +90,6 @@ public class JCacheConfiguration<K, V> implements javax.cache.configuration.Comp
                 cacheWristerFactory = null;
                 initialCacheEntryListenerConfigurations = new HashSet<CacheEntryListenerConfiguration<K, V>>();
             } else {
-                expiryPolicyFactory = null;
                 expiryPolicy = new ExpiryPolicy() {
                     @Override
                     public Duration getExpiryForCreation() {
@@ -106,6 +106,7 @@ public class JCacheConfiguration<K, V> implements javax.cache.configuration.Comp
                         return getExpiryForCreation();
                     }
                 };
+                expiryPolicyFactory = new FactoryBuilder.SingletonFactory<ExpiryPolicy>(expiryPolicy);
                 storeByValue = false;
                 readThrough = false;
                 writeThrough = false;

--- a/ehcache-jcache/src/test/java/org/ehcache/jcache/JCacheConfigurationTest.java
+++ b/ehcache-jcache/src/test/java/org/ehcache/jcache/JCacheConfigurationTest.java
@@ -1,0 +1,22 @@
+package org.ehcache.jcache;
+
+
+import org.junit.Test;
+
+import net.sf.ehcache.config.CacheConfiguration;
+
+public class JCacheConfigurationTest {
+
+    @Test
+    public void shouldCreateJCacheConfigurationFromOtherInstance() {
+        //given
+        CacheConfiguration ehCacheConfig = new CacheConfiguration("testCache", 1000);
+        JCacheConfiguration originJCacheConfig = new JCacheConfiguration(ehCacheConfig);
+
+        //when
+        new JCacheConfiguration(originJCacheConfig);
+        
+        //then - no Exception
+    }
+    
+}


### PR DESCRIPTION
fixes NPE if JCacheConfiguration is instatiated with other JCacheConfiguration

```java
        //given
        CacheConfiguration ehCacheConfig = new CacheConfiguration("testCache", 1000);
        JCacheConfiguration originJCacheConfig = new JCacheConfiguration(ehCacheConfig);

        //when
        new JCacheConfiguration(originJCacheConfig);
```
